### PR TITLE
replace for loop w/ torch primitives in sort_metric()

### DIFF
--- a/module.py
+++ b/module.py
@@ -33,11 +33,9 @@ class DPU_module(object):
         """Sort the metric (only the valid metric with mask value 1) and output a list that contains the information of top num_top weights"""
         valid_metric = (self.metric[self.mask]).view(-1)
         sorted_idx = torch.argsort(valid_metric, descending=True)
-        if num_top > self.num_updated_weights:
-            top_list = torch.tensor([ [ self.layer_idx, sorted_idx[i], valid_metric[sorted_idx[i]] ] for i in range(self.num_updated_weights)])  
-        else:
-            top_list = torch.tensor([ [ self.layer_idx, sorted_idx[i], valid_metric[sorted_idx[i]] ] for i in range(num_top)])  
-        return top_list
+        n = min(num_top, self.num_updated_weights)
+        layer_idcs = torch.full((n,), self.layer_idx).cuda()
+        return torch.stack((layer_idcs, sorted_idx[:n], valid_metric[sorted_idx[:n]]), dim=-1)
 
     def update_mask(self, act_list):
         """Update the mask according to the given list of active weights"""

--- a/multiround_dpu.py
+++ b/multiround_dpu.py
@@ -271,7 +271,7 @@ if __name__ == "__main__":
                 p_dpu.metric.add_(p_dpu.local_contribution)
 
         # Sort the metric across all layers and rewind the weights to their initial values according to the updating ratio
-        metric_list = torch.tensor([])
+        metric_list = torch.tensor([]).cuda()
         num_weights_total = 0
         for i, (p_dpu, p) in enumerate(zip(DPU_layers, parameters_w)):
             # Choose the top-65% weights in the i-th layer for the later global sorting

--- a/multiround_pruning.py
+++ b/multiround_pruning.py
@@ -234,7 +234,7 @@ if __name__ == "__main__":
         for p_dpu, p in zip(DPU_layers, parameters_w):
             p_dpu.metric.add_(torch.abs(p.data))
         # Sort the metric across all layers and prune the weights to zero according to the pruning ratio
-        metric_list = torch.tensor([])
+        metric_list = torch.tensor([]).cuda()
         num_weights_total = 0
         for i, (p_dpu, p) in enumerate(zip(DPU_layers, parameters_w)):
             # Choose the top-65% weights in the i-th layer for the later global sorting

--- a/multiround_reinit.py
+++ b/multiround_reinit.py
@@ -257,7 +257,7 @@ if __name__ == "__main__":
         
 
         # Sort the metric across all layers and rewind the weights to their initial values according to the updating ratio
-        metric_list = torch.tensor([])
+        metric_list = torch.tensor([]).cuda()
         num_weights_total = 0
         for i, (p_dpu, p) in enumerate(zip(DPU_layers, parameters_w)):
             # Choose the top-65% weights in the i-th layer for the later global sorting

--- a/singleround_dpu.py
+++ b/singleround_dpu.py
@@ -233,7 +233,7 @@ if __name__ == "__main__":
             p_dpu.metric.add_(args.lamda*p_dpu.global_contribution+(1-args.lamda)*p_dpu.local_contribution)
         
         # Sort the metric across all layers and rewind the weights to their initial values according to the updating ratio in the current iteration
-        metric_list = torch.tensor([])
+        metric_list = torch.tensor([]).cuda()
         num_weights_total = 0
         for i, (p_dpu, p) in enumerate(zip(DPU_layers, parameters_w)):
             # Choose the top-65% weights in the i-th layer for the later global sorting


### PR DESCRIPTION
Replacing this loop in `sort_metric()` translates to substantial speedup for larger layers. YMMV but we saw a ~99% decrease in time [here](https://github.com/zqu1992/DPU/blob/main/singleround_dpu.py#L236-L252) for a custom network (like 6 minutes to just under a second).

Try it yourself!

w/ @AdwaitB